### PR TITLE
✨ Feat: Added support for WEBP and AVIF formats

### DIFF
--- a/components/Logo.vue
+++ b/components/Logo.vue
@@ -1,10 +1,24 @@
 <template>
-  <img
-    class="w-20 h-20 rounded-full nuxt-logo border-6 border-primary"
-    src="https://res.cloudinary.com/de5xzoviz/image/upload/c_scale,q_58,w_640/v1592684920/pablosirera.jpg"
-    :alt="$t('general.altLogo')"
-    loading="lazy"
-  />
+  <picture>
+    <source
+      type="image/avif"
+      srcset="
+        https://res.cloudinary.com/de5xzoviz/image/upload/c_scale,w_640,f_avif/v1592684920/pablosirera.avif
+      "
+    >
+    <source
+      type="image/webp"
+      srcset="
+        https://res.cloudinary.com/de5xzoviz/image/upload/c_scale,q_65,w_640/v1592684920/pablosirera.webp
+      "
+    >
+    <img
+      class="w-20 h-20 rounded-full nuxt-logo border-6 border-primary"
+      src="https://res.cloudinary.com/de5xzoviz/image/upload/c_scale,q_50,w_640/v1592684920/pablosirera.jpg"
+      :alt="$t('general.altLogo')"
+      loading="lazy"
+    >
+  </picture>
 </template>
 
 <style>

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,5 @@
+[[headers]]
+  for = "*.avif"
+  [headers.values]
+    Content-Type = "image/avif"
+    Content-Disposition = "inline"

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -36,12 +36,27 @@
       </div>
       <!-- TODO: translate this text -->
       <div class="image-wrapper">
-        <img
-          class="image"
-          src="https://res.cloudinary.com/de5xzoviz/image/upload/v1596104201/desarrollador-web-setup.jpg"
-          alt="desarrollador web valencia"
-          loading="lazy"
-        />
+        <picture>
+          <!-- Cloudinary no sabe generar esta imagen 🤔🤷🏻‍♂️ -->
+          <!-- <source
+            type="image/avif"
+            srcset="
+              https://res.cloudinary.com/de5xzoviz/image/upload/q_25,f_avif/v1596104201/desarrollador-web-setup.avif
+            "
+          > -->
+          <source
+            type="image/webp"
+            srcset="
+              https://res.cloudinary.com/de5xzoviz/image/upload/q_25/v1596104201/desarrollador-web-setup.webp
+            "
+          >
+          <img
+            class="image"
+            src="https://res.cloudinary.com/de5xzoviz/image/upload/q_25/v1596104201/desarrollador-web-setup.jpg"
+            alt="desarrollador web valencia"
+            loading="lazy"
+          >
+        </picture>
       </div>
     </section>
     <section class="mt-12 md:grid md:grid-cols-2 md:gap-4">


### PR DESCRIPTION
Como te comenté en el streaming, añadir soporte para los formatos de WEBP y AV1 (AVIF) es muy sencillo gracias al elemento picture de HTML.

Lo ideal por sus características sería usar el formato AVIF, [gracias a sus ventajas](https://jakearchibald.com/2020/avif-has-landed/). Pero desgraciadamente su soporte todavía [no es el ideal](https://caniuse.com/avif), he incluso necesesita aplicar pequeñas modificaciones para que funcione en [Cloudinary](https://cloudinary.com/blog/image_formats_getting_it_right#next-gen) y [Netlify](https://reachlightspeed.com/blog/using-the-new-high-performance-avif-image-format-on-the-web-today/) (ver sección _AVIF Content-Type Headers + Netlify_). Aún así, sus ventajas son claras y sus desventajas solo temporales.

Como alternativa a la incompatibilidad con el formato AVIF, tenemos a disposición el formato WEBP con una [compatibilidad casi plena](https://caniuse.com/webp), lo que nos permite crear un fallback de calidad al futuro (inminente) de compatibilidad con AVIF.

Y como último recurso, en caso de una mala compatibilidad del navegador (no miro a nadie Internet Explorer, y Safari 👀😑), tenemos la carga del clásico JPG.